### PR TITLE
otimize graalvm v10 - fix bugs 11 - switch image to ubuntu arm, rever…

### DIFF
--- a/.github/workflows/dev-pipeline.yml
+++ b/.github/workflows/dev-pipeline.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - platform: linux/arm64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
             arch: arm64
           - platform: linux/amd64
             runner: ubuntu-latest


### PR DESCRIPTION
…t to work with ARG BUILDPLATFORM, remove cache

 add same runner: ubuntu-latest
switch to mvnw
improve profile default
add -Pnative no enable build native
change runner ubuntu-24.04-arm