### PR TITLE
otimize graalvm fix bugs 17 - switch image to ubuntu arm, revert to w…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ USER root
 # Install only wget & xz, allowing removals to fix glibc conflicts
 RUN microdnf install --nodocs -y \
       wget xz \
-      --allowerasing \
-      --nobest \
     && microdnf clean all
 
 


### PR DESCRIPTION
…ork with ARG BUILDPLATFORM, remove cache

 add same runner: ubuntu-latest
switch to mvnw
improve profile default
add -Pnative no enable build native
 march again, remove -muslib-ol9 and runner arm
 enable cache and SPRING_ACTIVE_PROFILE=cicd
 try to fix docker
 add wget