### PR TITLE
otimize graalvm fix bugs 17 - switch image to ubuntu arm, revert to w…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,19 @@ RUN echo "Building on: ${BUILDPLATFORM}, targeting: ${TARGETPLATFORM}"
 
 WORKDIR /app
 
-# 1) Install helper tools in one layer
+
+# Install only wget & xz
 USER root
-# Install only wget & xz, allowing removals to fix glibc conflicts
 RUN microdnf install --nodocs -y \
-      wget xz \
+      wget xz make gcc glibc-devel \
     && microdnf clean all
 
+# Install musl
+RUN wget -q https://musl.libc.org/releases/musl-1.2.5.tar.gz -O /tmp/musl-1.2.5.tar.gz \
+    && tar -xJf /tmp/musl-1.2.5.tar.gz -C /tmp \
+    && cd /tmp/musl-1.2.5 \
+    && ./configure --prefix=/usr/local/musl \
+    && make && make install
 
 # copy only what's needed for mvnw bootstrap
 COPY mvnw ./

--- a/pom.xml
+++ b/pom.xml
@@ -322,8 +322,9 @@
                         <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
 
                         <!-- musl compatibility -->
-                        <buildArg>--static-nolibc</buildArg>
-                        <!--<buildArg>-libc=musl</buildArg>-->
+                        <buildArg>--static</buildArg>
+                        <!--<buildArg>-static-nolibc</buildArg>-->
+                        <buildArg>--libc=musl</buildArg>
                         <buildArg>-H:-CheckToolchain</buildArg>
                         <buildArg>-H:+ReportUnsupportedElementsAtRuntime</buildArg>
 


### PR DESCRIPTION
…ork with ARG BUILDPLATFORM, remove cache

 add same runner: ubuntu-latest
switch to mvnw
improve profile default
add -Pnative no enable build native
 march again, and runner arm
 enable cache and SPRING_ACTIVE_PROFILE=cicd
 try to fix docker
 add wget
 add make to install musl
 enable static with