### PR TITLE
otimize graalvm fix bugs 18 - switch image to ubuntu arm, revert to w…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,12 @@ RUN microdnf install --nodocs -y \
     && microdnf clean all
 
 # Install musl
-RUN wget -q https://musl.libc.org/releases/musl-1.2.5.tar.gz -O /tmp/musl-1.2.5.tar.gz \
-    && tar -xJf /tmp/musl-1.2.5.tar.gz -C /tmp \
-    && cd /tmp/musl-1.2.5 \
-    && ./configure --prefix=/usr/local/musl \
-    && make && make install
+RUN wget -q https://musl.libc.org/releases/musl-1.2.5.tar.gz \
+     -O /tmp/musl-1.2.5.tar.gz && \
+    tar -xzf /tmp/musl-1.2.5.tar.gz -C /tmp && \
+    cd /tmp/musl-1.2.5 && \
+    ./configure --prefix=/usr/local/musl && \
+    make && make install
 
 # copy only what's needed for mvnw bootstrap
 COPY mvnw ./


### PR DESCRIPTION
…ork with ARG BUILDPLATFORM, remove cache

 add same runner: ubuntu-latest
switch to mvnw
improve profile default
add -Pnative no enable build native
 march again, and runner arm
 enable cache and SPRING_ACTIVE_PROFILE=cicd
 try to fix docker
 add wget
 add make to install musl
 enable static with
 fix make install and try to fix docker manifest