### PR TITLE
otimize graalvm fix bugs 20 - switch image to ubuntu arm, revert to w…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,14 +47,13 @@ RUN set -eux; \
     fi; \
     wget -q "https://github.com/graalvm/labs-openjdk/releases/download/${JDK_TAG}/${ASSET}" \
       -O "/tmp/${ASSET}"; \
-    # Create destination dir
     mkdir -p "/usr/lib64/graalvm/graalvm-community-java23/lib/static/${STATIC_SUBPATH}/musl"; \
-    # Extract only the musl static libs
     tar -xzf "/tmp/${ASSET}" \
       --strip-components=2 \
       -C "/usr/lib64/graalvm/graalvm-community-java23/lib/static/${STATIC_SUBPATH}/musl" \
-      "labsjdk-ce-${JDK_TAG}-linux-${STATIC_SUBPATH}/lib/static/${STATIC_SUBPATH}/musl"; \
+      "labsjdk-ce-${JDK_TAG}-${STATIC_SUBPATH}/lib/static/${STATIC_SUBPATH}/musl"; \
     rm "/tmp/${ASSET}"
+
 
 # copy only what's needed for mvnw bootstrap
 COPY mvnw ./


### PR DESCRIPTION
…ork with ARG BUILDPLATFORM, remove cache

 add same runner: ubuntu-latest
switch to mvnw
improve profile default
add -Pnative no enable build native
 march again, and runner arm
 enable cache and SPRING_ACTIVE_PROFILE=cicd
 try to fix docker
 add wget
 add make to install musl
 enable static with
 fix make install and try to fix docker manifest
 try new way to install musl an link it
 add labs-openjdk arm and amd