### PR TITLE
otimize graalvm fix bugs 23 - switch image to ubuntu arm, revert to w…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 # Install only wget & xz
 USER root
 RUN microdnf install --nodocs -y \
-      wget xz make gcc \
+      wget xz make gcc findutils \
     && microdnf clean all
 
 # -----------------------------
@@ -59,10 +59,6 @@ RUN set -eux; \
     mkdir -p "${DEST}"; \
     cp -r "${STATIC_SRC}/." "${DEST}/"; \
     rm -rf /tmp/jdk
-
-
-
-
 
 # copy only what's needed for mvnw bootstrap
 COPY mvnw ./


### PR DESCRIPTION
…ork with ARG BUILDPLATFORM, remove cache

 add same runner: ubuntu-latest
switch to mvnw
improve profile default
add -Pnative no enable build native
 march again, and runner arm
 enable cache and SPRING_ACTIVE_PROFILE=cicd
 try to fix docker
 add wget
 add make to install musl
 enable static with
 fix make install and try to fix docker manifest
 try new way to install musl an link it
 add labs-openjdk arm and amd
 install findutils